### PR TITLE
Put traces public

### DIFF
--- a/src/DebugStack.php
+++ b/src/DebugStack.php
@@ -6,7 +6,7 @@ use Doctrine\DBAL\Logging\SQLLogger;
 
 class DebugStack implements SQLLogger
 {
-    private $traces = [];
+    public $traces = [];
     public ?Trace $currentTrace = null;
 
     public function __construct(private Tempo $tempo)


### PR DESCRIPTION
In order to access it into potential Subscriber.
Example : count number of traces generated by this SQLLogger, as it can be done with the Doctrine DebugStack.